### PR TITLE
Add bundle files for browser environments

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,12 @@
+{
+	"presets": [
+		[
+			"env",
+			{
+				"targets": {
+					"browsers": ["last 4 versions", "not ie <= 10"]
+				}
+			}
+		]
+	]
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,25 +9,37 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          name: Set NPM user
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+      - restore_cache:
+          key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Install dependencies
           command: npm i
       - save_cache:
-          key: build-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+      - save_cache:
+          key: install-cache-{{ .Revision }}
           paths:
             - ../app
+  lint:
+    <<: *defaults
+    steps:
+      - checkout
+      - restore_cache:
+          key: install-cache-{{ .Revision }}
+      - run:
+          name: Check code syntax
+          command: npm run lint
   test:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
-          key: build-cache-{{ .Revision }}
+          key: install-cache-{{ .Revision }}
       - run:
           name: Test
-          command: ./packages/run-all-the-things/index.js test lint
+          command: npm run test
           environment:
             MOCHA_FILE: junit/test-results.xml
           when: always
@@ -40,7 +52,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: build-cache-{{ .Revision }}
+          key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Create this repo's readme
           command: npm run readme
@@ -50,15 +62,27 @@ jobs:
       - run:
           name: Update changes
           command: curl ci-cd.net/v1/git/update | bash
-  publish:
+  bundle:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
-          key: build-cache-{{ .Revision }}
+          key: install-cache-{{ .Revision }}
       - run:
-          name: Set NPM user
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          name: Create bundle distribution files
+          command: npm run bundle
+      - save_cache:
+          key: bundle-cache-{{ .Revision }}
+          paths:
+            - ../app
+  publish:
+    <<: *defaults
+    steps:
+      - restore_cache:
+          key: bundle-cache-{{ .Revision }}
+      - run:
+          name: Set NPM tokens
+          command: echo -e $NPMRC > ~/.npmrc
       - run:
           name: Publish to NPM
           command: npm run publish-packages
@@ -67,10 +91,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: build-cache-{{ .Revision }}
-      - run:
-          name: Set NPM user
-          command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
+          key: dependency-cache-{{ checksum "package.json" }}
       - run:
           name: Create the docs
           command: npm run doc
@@ -87,16 +108,25 @@ workflows:
     jobs:
       - install:
           context: globalenv
+      - lint:
+          requires:
+            - install
       - test:
           requires:
             - install
+      - bundle:
+          requires:
+            - install
+      - readme:
+          requires:
+            - test
+            - lint
       - publish:
           context: globalenv
           requires:
             - test
-      - readme:
-          requires:
-            - test
+            - lint
+            - bundle
       - docs:
           context: globalenv
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,15 +62,15 @@ jobs:
       - run:
           name: Update changes
           command: curl ci-cd.net/v1/git/update | bash
-  bundle:
+  dist:
     <<: *defaults
     steps:
       - checkout
       - restore_cache:
           key: install-cache-{{ .Revision }}
       - run:
-          name: Create bundle distribution files
-          command: npm run bundle
+          name: Create distribution files
+          command: npm run dist
       - save_cache:
           key: bundle-cache-{{ .Revision }}
           paths:
@@ -114,7 +114,7 @@ workflows:
       - test:
           requires:
             - install
-      - bundle:
+      - dist:
           requires:
             - install
       - readme:
@@ -126,7 +126,7 @@ workflows:
           requires:
             - test
             - lint
-            - bundle
+            - dist
       - docs:
           context: globalenv
           requires:

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
-node_modules
+/node_modules/*
+**/node_modules/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -15,7 +15,7 @@
 	},
 	"overrides": [
 		{
-			"files": [ "**/spec.js" ],
+			"files": [ "**/spec.js", "**/test.js" ],
 			"env": {
 				"mocha": true
 			},
@@ -24,6 +24,12 @@
 				"assert": true,
 				"sleep": true,
 				"freeze": true
+			}
+		},
+		{
+			"files": [ "**/selenium-chrome-clear-cache/*" ],
+			"env": {
+				"browser": true
 			}
 		}
 	]

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 package-lock.json
 docs
 junit
-bundle/
+dist/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 package-lock.json
 docs
 junit
+bundle/

--- a/bundles/entries.js
+++ b/bundles/entries.js
@@ -1,0 +1,36 @@
+const {resolve} = require('path');
+const {readdirSync} = require('fs');
+const packageDir = (...args) => resolve(
+	__dirname,
+	'../packages',
+	...args
+);
+
+module.exports = readdirSync(packageDir())
+	.reduce(
+		(accumulator, pkg) => {
+			try {
+				const {
+					browser,
+					main,
+					scripts,
+				} = require(
+					packageDir(pkg, 'package.json')
+				);
+
+				if (scripts.bundle) {
+					throw new Error('I\'ll bundle myself, thank you very much.')
+				}
+
+				const entry = browser && main ?
+					{[packageDir(pkg, browser)]: packageDir(pkg, main)}
+					:
+					{}
+				;
+				return Object.assign(accumulator, entry);
+			} catch (error) {
+				return accumulator;
+			}
+		},
+		{}
+	);

--- a/bundles/test.js
+++ b/bundles/test.js
@@ -1,0 +1,21 @@
+const {resolve} = require('path');
+const entries = require('./entries');
+
+describe(
+	'bundle files',
+	() => Object.keys(entries)
+		.forEach(
+			pkg => it(
+				`Should expose "${pkg
+					.replace(resolve(__dirname, '../packages'), '')
+					.split('/')
+					.filter(i => !!i)
+					.shift()}" bundle as a consumable module`,
+				() => {
+					if (typeof require(pkg) !== 'function') {
+						throw new TypeError(`${pkg} module should expose a function`);
+					}
+				}
+			)
+		)
+);

--- a/dists/entries.js
+++ b/dists/entries.js
@@ -18,8 +18,8 @@ module.exports = readdirSync(packageDir())
 					packageDir(pkg, 'package.json')
 				);
 
-				if (scripts.bundle) {
-					throw new Error('I\'ll bundle myself, thank you very much.')
+				if (scripts.dist) {
+					throw new Error('I\'ll create my own dist files, thank you very much.')
 				}
 
 				const entry = browser && main ?

--- a/dists/test.js
+++ b/dists/test.js
@@ -2,7 +2,7 @@ const {resolve} = require('path');
 const entries = require('./entries');
 
 describe(
-	'bundle files',
+	'create dist files',
 	() => Object.keys(entries)
 		.forEach(
 			pkg => it(
@@ -10,7 +10,7 @@ describe(
 					.replace(resolve(__dirname, '../packages'), '')
 					.split('/')
 					.filter(i => !!i)
-					.shift()}" bundle as a consumable module`,
+					.shift()}" dist as a consumable module`,
 				() => {
 					if (typeof require(pkg) !== 'function') {
 						throw new TypeError(`${pkg} module should expose a function`);

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "url": "git+https://github.com/omrilotan/mono.git"
   },
   "scripts": {
-    "test": "./scripts/test.sh",
-    "lint": "eslint -c .eslintrc *.js **/*.js --quiet",
+    "clean": "./scripts/foreach.sh \"rm -rf bundle\"",
     "postinstall": "./scripts/foreach.sh \"npm i\"",
-    "prepublish-packages": "npm t; npm run lint",
+    "test": "./scripts/test.sh",
+    "lint": "eslint -c .eslintrc '*.js' '**/*.js' --quiet",
+    "bundle": "./packages/run-all-the-things/index.js webpack babel",
+    "webpack": "webpack --config webpack.config.js",
+    "babel": "./scripts/foreach.sh \"npm run bundle\"",
+    "postbundle": "npx mocha bundles/test.js",
     "publish-packages": "./scripts/foreach.sh \"npx published\"",
     "predoc": "./scripts/doc.sh",
     "doc": "node ./scripts/homepage.js",
@@ -21,17 +25,19 @@
     "readme": "node ./scripts/readme.js"
   },
   "devDependencies": {
+    "babel-cli": "^6.26.0",
+    "babel-core": "^6.26.3",
+    "babel-loader": "^7.1.5",
+    "babel-preset-env": "^1.7.0",
     "chai": "^4.1.2",
     "chai-string": "^1.4.0",
     "dont-look-up": "^1.0.0",
     "eslint": "^5.0.0",
     "mocha": "^5.2.0",
     "mocha-junit-reporter": "^1.17.0",
-    "node-sass": "^4.9.0"
+    "node-sass": "^4.9.0",
+    "webpack": "^4.16.2",
+    "webpack-cli": "^3.1.0"
   },
-  "private": true,
-  "publishConfig": {
-    "tag": "after-next",
-    "tag-version-prefix": "next-tag"
-  }
+  "private": true
 }

--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
     "url": "git+https://github.com/omrilotan/mono.git"
   },
   "scripts": {
-    "clean": "./scripts/foreach.sh \"rm -rf bundle\"",
+    "clean": "./scripts/foreach.sh \"rm -rf dist\"",
     "postinstall": "./scripts/foreach.sh \"npm i\"",
     "test": "./scripts/test.sh",
     "lint": "eslint -c .eslintrc '*.js' '**/*.js' --quiet",
-    "bundle": "./packages/run-all-the-things/index.js webpack babel",
+    "dist": "./packages/run-all-the-things/index.js webpack babel",
     "webpack": "webpack --config webpack.config.js",
-    "babel": "./scripts/foreach.sh \"npm run bundle\"",
-    "postbundle": "npx mocha bundles/test.js",
+    "babel": "./scripts/foreach.sh \"npm run dist\"",
+    "postdist": "npx mocha dists/test.js",
     "publish-packages": "./scripts/foreach.sh \"npx published\"",
     "predoc": "./scripts/doc.sh",
     "doc": "node ./scripts/homepage.js",

--- a/packages/assign/README.md
+++ b/packages/assign/README.md
@@ -7,3 +7,11 @@ const assign = require('@(._.)/assign');
 
 assign({hash: {a: 1}}, {hash: {b: 2, c: 0}}, {hash: {c: 3}}) // {hash: {a: 1, b:2, c: 3}}
 ```
+
+## Transpiled version
+Environments which exclude node_modules from the transpiling pipeline should include the "browser" entry instead of "main". This exposes an ES5 commonjs module.
+
+Also available for explicit import:
+```js
+const assign = require('assign/bundle');
+```

--- a/packages/assign/package.json
+++ b/packages/assign/package.json
@@ -10,9 +10,9 @@
 	},
 	"homepage": "https://omrilotan.com/mono/assign/",
 	"main": "index.js",
-	"browser": "bundle/index.js",
+	"browser": "dist/index.js",
 	"scripts": {
-		"bundle": "mkdir -p bundle; babel index.js --out-file bundle/index.js",
+		"dist": "mkdir -p dist; babel index.js --out-file dist/index.js",
 		"test": "cd ../../; npm t assign; cd -"
 	}
 }

--- a/packages/assign/package.json
+++ b/packages/assign/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@(._.)/assign",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"description": "Object deep assign",
 	"author": "omrilotan",
 	"license": "MIT",
@@ -10,7 +10,9 @@
 	},
 	"homepage": "https://omrilotan.com/mono/assign/",
 	"main": "index.js",
+	"browser": "bundle/index.js",
 	"scripts": {
+		"bundle": "mkdir -p bundle; babel index.js --out-file bundle/index.js",
 		"test": "cd ../../; npm t assign; cd -"
 	}
 }

--- a/packages/notate/README.md
+++ b/packages/notate/README.md
@@ -23,5 +23,5 @@ Environments which exclude node_modules from the transpiling pipeline should inc
 
 Also available for explicit import:
 ```js
-const notate = require('notate/bundle');
+const notate = require('notate/dist');
 ```

--- a/packages/notate/README.md
+++ b/packages/notate/README.md
@@ -17,3 +17,11 @@ notate(obj, 'top_level.nested.value') // 'My Value'
 
 notate(obj, 'top_level.missing.value') // undefined
 ```
+
+## Transpiled version
+Environments which exclude node_modules from the transpiling pipeline should include the "browser" entry instead of "main". This exposes an ES5 commonjs module.
+
+Also available for explicit import:
+```js
+const notate = require('notate/bundle');
+```

--- a/packages/notate/package.json
+++ b/packages/notate/package.json
@@ -10,9 +10,9 @@
 	},
 	"homepage": "https://omrilotan.com/mono/notate/",
 	"main": "index.js",
-	"browser": "bundle/index.js",
+	"browser": "dist/index.js",
 	"scripts": {
-		"bundle": "mkdir -p bundle; babel index.js --out-file bundle/index.js",
+		"dist": "mkdir -p dist; babel index.js --out-file dist/index.js",
 		"test": "cd ../../; npm t notate; cd -"
 	}
 }

--- a/packages/notate/package.json
+++ b/packages/notate/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "notate",
-	"version": "1.0.1",
+	"version": "1.1.0",
 	"description": "Resolve dot notation strings",
 	"author": "omrilotan",
 	"license": "MIT",
@@ -10,7 +10,9 @@
 	},
 	"homepage": "https://omrilotan.com/mono/notate/",
 	"main": "index.js",
+	"browser": "bundle/index.js",
 	"scripts": {
+		"bundle": "mkdir -p bundle; babel index.js --out-file bundle/index.js",
 		"test": "cd ../../; npm t notate; cd -"
 	}
 }

--- a/packages/oh-my-gauge/spec.js
+++ b/packages/oh-my-gauge/spec.js
@@ -18,7 +18,7 @@ describe('oh-my-gauge', () => {
 		expect(require.cache[require.resolve('./lib/gauge')]).to.be.undefined;
 		expect(require.cache[require.resolve('./lib/benchmark')]).to.be.undefined;
 
-		const { Gauge, Benchmark } = require('.'); // eslint-disable-line no-unused
+		const { Gauge, Benchmark } = require('.'); // eslint-disable-line no-unused-vars
 
 		expect(require.cache[require.resolve('./lib/gauge')]).to.not.be.undefined;
 		expect(require.cache[require.resolve('./lib/benchmark')]).to.not.be.undefined;

--- a/packages/paraphrase/README.md
+++ b/packages/paraphrase/README.md
@@ -80,5 +80,5 @@ Environments which exclude node_modules from the transpiling pipeline should inc
 
 Also available for explicit import:
 ```js
-const paraphrase = require('paraphrase/bundle');
+const paraphrase = require('paraphrase/dist');
 ```

--- a/packages/paraphrase/README.md
+++ b/packages/paraphrase/README.md
@@ -45,7 +45,6 @@ phrase('Hello, ${0} ${1}', ['Martin', 'Prince']); // Hello, Martin Prince
 phrase('Hello, ${0} ${1}', 'Martin', 'Prince'); // Hello, Martin Prince
 ```
 
-
 ## Premade
 
 ### dollar `${...}`
@@ -74,4 +73,12 @@ phrase('Hello, %{name}', {name: 'Martin'}); // Hello, Martin
 const phrase = require('paraphrase/hash');
 
 phrase('Hello, #{name}', {name: 'Martin'}); // Hello, Martin
+```
+
+## Bundled version
+Environments which exclude node_modules from the transpiling pipeline should include the "browser" entry instead of "main". This exposes a bundled ES5 commonjs module.
+
+Also available for explicit import:
+```js
+const paraphrase = require('paraphrase/bundle');
 ```

--- a/packages/paraphrase/package.json
+++ b/packages/paraphrase/package.json
@@ -10,7 +10,7 @@
 	},
 	"homepage": "https://omrilotan.com/mono/paraphrase/",
 	"main": "index.js",
-	"browser": "bundle/index.js",
+	"browser": "dist/index.js",
 	"scripts": {
 		"test": "cd ../../; npm t paraphrase; cd -"
 	},

--- a/packages/paraphrase/package.json
+++ b/packages/paraphrase/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "paraphrase",
-	"version": "1.2.2",
+	"version": "1.3.0",
 	"description": "Create flavoured string phraser",
 	"author": "omrilotan",
 	"license": "MIT",
@@ -10,6 +10,7 @@
 	},
 	"homepage": "https://omrilotan.com/mono/paraphrase/",
 	"main": "index.js",
+	"browser": "bundle/index.js",
 	"scripts": {
 		"test": "cd ../../; npm t paraphrase; cd -"
 	},

--- a/packages/selenium-chrome-clear-cache/index.js
+++ b/packages/selenium-chrome-clear-cache/index.js
@@ -48,6 +48,10 @@ const find = (selector) => document.querySelector(selector);
  * await clearCache({webdriver, driver});
  */
 module.exports = async function clearCache({webdriver, driver}, {cookies = false, cache = true, history = true} = {}) {
+	if (!(cookies || cache || history)) {
+		return;
+	}
+
 	const { By, until } = webdriver;
 
 	await driver.get(PAGE);

--- a/packages/selenium-chrome-clear-cache/package.json
+++ b/packages/selenium-chrome-clear-cache/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "selenium-chrome-clear-cache",
-	"version": "1.1.0",
+	"version": "1.1.1",
 	"description": "Clear cache of Chrome in Selenium",
 	"author": "omrilotan",
 	"license": "MIT",

--- a/packages/selenium-chrome-clear-cache/spec.js
+++ b/packages/selenium-chrome-clear-cache/spec.js
@@ -45,7 +45,7 @@ describe('selenium-chrome-clear-cache', async() => {
 			expect(loadTimes[2]).not.to.be.below(loadTimes[1]);
 		}).timeout(TIMEOUT).retries(RETRIES);
 
-		it(`Load times should	decrease with cache and stay low after de-selecting all checkboxes (${3 - i}/3)`, async() => {
+		it(`Load times should	decrease with cache and stay low after de-selecting history and cache (${3 - i}/3)`, async() => {
 			const loadTimes = [];
 
 			await driver.get(`${LINK}?${i}`);
@@ -54,7 +54,7 @@ describe('selenium-chrome-clear-cache', async() => {
 			await driver.get(`${LINK}?${i}`);
 			loadTimes.push(await driver.executeScript(MEASURE));
 
-			await clearCache({webdriver, driver}, {cache: false, history: false});
+			await clearCache({webdriver, driver}, {cache: false, history: false, cookies: true});
 
 			await driver.get(`${LINK}?${i}`);
 			loadTimes.push(await driver.executeScript(MEASURE));
@@ -68,4 +68,12 @@ describe('selenium-chrome-clear-cache', async() => {
 			);
 		}).timeout(TIMEOUT).retries(RETRIES);
 	}
+
+	it('Should not try to click the disabled button when no checkboxes are marked', async() => {
+		try {
+			await clearCache({webdriver, driver}, {cache: false, history: false});
+		} catch (error) {
+			throw error;
+		}
+	});
 });

--- a/packages/twinsies/lib/safe/spec.js
+++ b/packages/twinsies/lib/safe/spec.js
@@ -1,4 +1,3 @@
-const {assert, expect} = require('chai');
 const safe = require('./');
 
 describe('lib', () => {

--- a/scripts/homepage.js
+++ b/scripts/homepage.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+process.on('unhandledRejection', (error) => { throw error; });
+
 const fs = require('fs').promises;
 const phrase = require('../packages/paraphrase/double');
 
@@ -15,6 +17,7 @@ const phrase = require('../packages/paraphrase/double');
 					name,
 					description,
 					version,
+					browser,
 				} = require(`../packages/${item}/package.json`);
 
 				if (version.includes('alpha') || version.includes('beta')) {
@@ -26,7 +29,7 @@ const phrase = require('../packages/paraphrase/double');
 				rows.push(`
 <tr>
 	<td><a href="${link}">${name}</a></td>
-	<td>${description}</td>
+	<td>${description}${browser ? ' <i title="includes browser entry">🖥</i>' : ''}</td>
 	<td><a href="https://www.npmjs.com/package/${name}"><small>${version}</small></a></td>
 </tr>
 `);

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -68,6 +68,13 @@ th, td, pre, code {
 	padding: .2em .5em;
 }
 
+table i {
+	float: right;
+	margin-left: .5em
+	font-style: normal;
+	cursor: help;
+}
+
 pre > code {
 	padding: 0;
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,24 @@
+const {resolve} = require('path');
+const entry = require('./bundles/entries');
+
+module.exports = {
+	mode: 'production',
+	entry,
+	output: {
+		filename: '[name]',
+		path: resolve('/'),
+		libraryTarget: 'commonjs2',
+	},
+	module: {
+		rules: [
+			{
+				test: /\.m?js$/,
+				loader: 'babel-loader',
+				include: __dirname,
+				options: {
+					cacheDirectory: true,
+				},
+			}
+		],
+	},
+};

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 const {resolve} = require('path');
-const entry = require('./bundles/entries');
+const entry = require(resolve(__dirname, 'dists', 'entries'));
 
 module.exports = {
 	mode: 'production',


### PR DESCRIPTION
This will allow these packages to be included, outof the box, in projects who bundle for browsers or older environments but exclude node_modules from the babel pipeline